### PR TITLE
book_ticker: missing "ticker/" part in URI path "/api/v1/ticker/bookT…

### DIFF
--- a/lib/Binance/API.pm
+++ b/lib/Binance/API.pm
@@ -753,7 +753,7 @@ sub book_ticker {
         symbol    => $params{'symbol'},
     };
 
-    return $self->ua->get('/api/v1/bookTicker', { query => $query } );
+    return $self->ua->get('/api/v1/ticker/bookTicker', { query => $query } );
 }
 
 =head2 order


### PR DESCRIPTION
missing part in path causes a HTTP 404 error.