### PR TITLE
Support for cancelling all open orders

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+Unreleased
+    - Support for cancelling all open orders
+
 1.07 Thu Aug  12 22:11:46 UTC 2021
     - Upgrade to API Version 3
     - Fix book_ticker

--- a/lib/Binance/API.pm
+++ b/lib/Binance/API.pm
@@ -1016,6 +1016,59 @@ sub cancel_order {
     return $self->ua->delete('/api/v3/order', { signed => 1, body => $body } );
 }
 
+=head2 cancel_open_orders
+
+    $api->cancel_open_orders( symbol => 'ETHBTC' );
+
+Cancel all active orders for a given symbol.
+
+B<PARAMETERS>
+
+=over
+
+=item symbol
+
+[REQUIRED] Symbol, for example C<ETHBTC>.
+
+=item recvWindow
+
+[OPTIONAL]
+
+=back
+
+B<RETURNS>
+    An ARRAYref of HASHrefs
+
+    [
+      {
+        "symbol": "ETHBTC",
+        "origClientOrderId": "myOrder1",
+        "orderId": 1,
+        "clientOrderId": "cancelMyOrder1"
+      }
+    ]
+
+=cut
+
+sub cancel_open_orders {
+    my ($self, %params) = @_;
+
+    unless ($params{'symbol'}) {
+        $self->log->error('Parameter "symbol" required');
+        Binance::Exception::Parameter::Required->throw(
+            error => 'Parameter "symbol" required',
+            parameters => ['symbol']
+        );
+    }
+
+    my $body = {
+        symbol             => $params{'symbol'},
+        recvWindow         => $params{'recvWindow'},
+    };
+
+    return $self->ua->delete('/api/v3/openOrders', { signed => 1, body => $body } );
+}
+
 =head2 open_orders
 
     $api->open_orders();


### PR DESCRIPTION
This adds support for the API call here:

https://binance-docs.github.io/apidocs/spot/en/#cancel-all-open-orders-on-a-symbol-trade

so that you don't have to iterate through the list of open orders cancelling individually. 