### PR TITLE
Add baseUrl param to Binance::API->new()

### DIFF
--- a/lib/Binance/API.pm
+++ b/lib/Binance/API.pm
@@ -92,6 +92,10 @@ B<PARAMETERS>
 [OPTIONAL] Number of milliseconds the request is valid for. Applies only in
 signed requests.
 
+=item baseUrl
+
+[OPTIONAL] Base URL of Binance endpoint.
+
 =item logger
 
 [OPTIONAL] See L<Binance::API::Logger/new>
@@ -113,6 +117,7 @@ sub new {
         apiKey     => $params{apiKey},
         secretKey  => $params{secretKey},
         recvWindow => $params{recvWindow},
+        baseUrl    => $params{baseUrl},
         logger     => $logger,
     );
 

--- a/lib/Binance/API/Request.pm
+++ b/lib/Binance/API/Request.pm
@@ -56,6 +56,7 @@ sub new {
         apiKey     => $params{'apiKey'},
         secretKey  => $params{'secretKey'},
         recvWindow => $params{'recvWindow'},
+        baseUrl    => $params{'baseUrl'},
         logger     => $params{'logger'},
     };
 
@@ -143,7 +144,8 @@ sub _init {
 
     $timestamp //= int Time::HiRes::time * 1000 if $params->{'signed'};
 
-    my $uri = URI->new( BASE_URL . $path );
+    my $base_url = defined $self->{'baseUrl'} ? $self->{'baseUrl'} : BASE_URL;
+    my $uri = URI->new( $base_url . $path );
     my $full_path = $uri->as_string;
 
     my %data;


### PR DESCRIPTION
Add baseUrl parameter for simpler switching to `https://testnet.binance.vision` endpoint. 